### PR TITLE
Update to Oauth2

### DIFF
--- a/indicomobile/__init__.py
+++ b/indicomobile/__init__.py
@@ -6,21 +6,9 @@ from indicomobile.views.assets import register_assets
 from indicomobile.views.errors import register_errors
 from indicomobile.util.json import patch_json
 
+
 patch_json()
 app = Flask(__name__)
-
-
-# Patch to set the certificate for SSL Verification
-import httplib2
-
-
-class Http(httplib2.Http):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('ca_certs', app.config['CERT_FILE'])
-        super(Http, self).__init__(*args, **kwargs)
-
-httplib2.Http = Http
-# End of path
 
 
 def setup_blueprints(app):

--- a/indicomobile/__init__.py
+++ b/indicomobile/__init__.py
@@ -10,17 +10,30 @@ patch_json()
 app = Flask(__name__)
 
 
+# Patch to set the certificate for SSL Verification
+import httplib2
+
+
+class Http(httplib2.Http):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('ca_certs', app.config['CERT_FILE'])
+        super(Http, self).__init__(*args, **kwargs)
+
+httplib2.Http = Http
+# End of path
+
+
 def setup_blueprints(app):
     from indicomobile.views.routing import routing
     from indicomobile.views.events import events
     from indicomobile.views.favorites import favorites
-    from indicomobile.views.authentication import oauth_client
+    from indicomobile.views.authentication import oauth_blueprint
     from indicomobile.views.maps import maps
 
     app.register_blueprint(routing)
     app.register_blueprint(events)
     app.register_blueprint(favorites)
-    app.register_blueprint(oauth_client)
+    app.register_blueprint(oauth_blueprint)
     app.register_blueprint(maps)
 
 

--- a/indicomobile/core/indico_api.py
+++ b/indicomobile/core/indico_api.py
@@ -1,11 +1,11 @@
-import urllib2
 import urllib
 
 import requests
+from requests.exceptions import HTTPError
+from urlparse import urljoin
 
-from flask import json, session as flask_session, abort
+from flask import session, abort
 from indicomobile import app
-from indicomobile.util.tools import construct_url
 from indicomobile.views.authentication import indico
 
 
@@ -16,94 +16,87 @@ def attach_params(params):
     return urllib.urlencode(items)
 
 
-def perform_signed_request(url):
-    response = indico.get(url)
-    if response.status_code != requests.codes.ok:
-        abort(response.status)
-    return response.raw
+def perform_request(path, params=None, signed=None):
+    """Performs an HHTP GET request to the Indico API.
 
+    In the case of a signed request, the API key is automatically added.
+    But you are free to define a different key  (``ak``) in the params.
 
-def perform_public_request(url):
+    :param path: str -- the API path for the resource to get
+    :param params: (optional) Dictionary or bytes to be sent in the
+                   query string
+    :param signed: Whether to perform a signed request or not. If
+                   omitted, the request will be signed if an oauth token
+                   is present.
+    """
+    url = urljoin(app.config['INDICO_URL'], path)
+    params = params or {}
+    if signed is None:
+        signed = 'indico_mobile_oauthtok' in session
+    if signed:
+        params.setdefault('ak', app.config['API_KEY'])
+    get_request = indico.get if signed else requests.get
+    verify = app.config.get('CERT_FILE') or True
+    response = get_request(url, params=params, verify=verify)
     try:
-        f = urllib2.urlopen(url)
-        return f.read()
-    except urllib2.HTTPError, err:
-        abort(err.code)
+        response.raise_for_status()
+    except HTTPError as err:
+        abort(err.response.status)
+    return response.json()
 
 
-def search_event(search, pageNumber):
+def search_event(query, page_number):
     try:
-        search = urllib.quote(search)
+        query = urllib.quote(query)
     except Exception:
         return []
-    path = '/export/event/search/' + search + '.json'
+    path = '/export/event/search/{query}.json'.format(query=query)
     params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no',
               'order': 'start',
               'descending': 'yes',
               'limit': 20,
-              'offset': (pageNumber - 1) * 20}
-    if 'indico_mobile_oauthtok' in flask_session:
-        result = perform_signed_request(construct_url(path, attach_params(params)))
-    else:
-        params['ak'] = app.config['API_KEY']
-        result = perform_public_request(construct_url(path, attach_params(params)))
-    return json.loads(result.decode('utf-8'))['results']
+              'offset': (page_number - 1) * 20}
+    response = perform_request(path, params=params)
+    return response['results']
 
 
 def get_event_info(event_id):
-    path = '/export/event/' + event_id + '.json'
+    path = '/export/event/{event_id}.json'.format(event_id=event_id)
     params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no'}
-    if 'indico_mobile_oauthtok' in flask_session:
-        result = perform_signed_request(construct_url(path, attach_params(params)))
-    else:
-        params['ak'] = app.config['API_KEY']
-        result = perform_public_request(construct_url(path, attach_params(params)))
-    event_info = json.loads(result.decode('utf-8'))['results']
-    if not event_info:
-        return None
-    return event_info[0]
+    signed = 'indico_mobile_oauthtok' in session
+    response = perform_request(path, params=params, signed=signed)
+    event_info = response['results']
+    return event_info[0] if event_info else None
 
 
 def fetch_timetable(event_id):
-    path = '/export/timetable/' + event_id + '.json'
-    if 'indico_mobile_oauthtok' in flask_session:
-        params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no'}
-        result = perform_signed_request(construct_url(path, attach_params(params)))
-    else:
-        {'ak': app.config['API_KEY']}
-        result = perform_public_request(construct_url(path, attach_params(params)))
-    return json.loads(result.decode('utf-8'))['results']
+    path = '/export/timetable/{event_id}.json'.format(event_id=event_id)
+    params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no'}
+    response = perform_request(path, params=params)
+    return response['results']
 
 
 def get_ongoing_events():
-    result = perform_public_request('{0[INDICO_URL]}/export/categ/0.json?ak={0[API_KEY]}&from=now&to=now'
-                                    .format(app.config))
-    return json.loads(result.decode('utf-8'))['results']
+    response = perform_request('/export/categ/0.json', params={'from': 'now', 'to': 'now'}, signed=False)
+    return response['results']
 
 
 def get_today_events(user_id):
     return get_future_events(user_id, 'now', 'today')
 
 
-def get_future_events(user_id, startDate, endDate):
+def get_future_events(user_id, start_date, end_date):
     path = '/export/categ/0.json'
     params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no',
-              'from': startDate,
-              'to': endDate,
+              'from': start_date,
+              'to': end_date,
               'order': 'start'}
-    if user_id != 'all_public':
-        result = perform_signed_request(construct_url(path, attach_params(params)))
-    else:
-        params['ak'] = app.config['API_KEY']
-        result = perform_public_request(construct_url(path, attach_params(params)))
-    result = json.loads(result.decode('utf-8'))
-    return result['results'], result['additionalInfo']['moreFutureEvents']
+    signed = user_id != 'all_public'
+    response = perform_request(path, params=params, signed=signed)
+    return response['results'], response['additionalInfo']['moreFutureEvents']
 
 
 def get_room(room_name):
-    path = '/export/roomName/CERN/' + urllib.quote(room_name) + '.json'
-    if 'indico_mobile_oauthtok' in flask_session:
-        result = perform_signed_request(construct_url(path, attach_params({})))
-    else:
-        result = perform_public_request(construct_url(path, attach_params({'ak': app.config['API_KEY']})))
-    return json.loads(result.decode('utf-8'))['results']
+    path = '/export/roomName/CERN/{room_name}.json'.format(urllib.quote(room_name))
+    response = perform_request(path)
+    return response['results']

--- a/indicomobile/core/indico_api.py
+++ b/indicomobile/core/indico_api.py
@@ -3,28 +3,32 @@ import urllib
 from urlparse import urlparse, urlunparse
 
 from flask import json, session as flask_session, abort
-from indicomobile.views.authentication import oauth_indico_mobile
+from indicomobile.views.authentication import indico
 from indicomobile import app
+
 
 def construct_url(path, params):
     url_fragments = urlparse(app.config['INDICO_URL'])
     url_path = url_fragments.path
-    if url_path and url_path[-1] == "/":
+    if url_path and url_path[-1] == '/':
         url_path = url_path[:-1]
     url_path += path
-    return urlunparse((url_fragments.scheme, url_fragments.netloc, url_path , "", params, ""))
+    return urlunparse((url_fragments.scheme, url_fragments.netloc, url_path, '', params, ''))
+
 
 def attach_params(params):
     items = params.items() if hasattr(params, 'items') else list(params)
     if not items:
-        return ""
+        return ''
     return urllib.urlencode(items)
 
+
 def perform_signed_request(url):
-    response = oauth_indico_mobile.get(url)
+    response = indico.get(url)
     if response.status != 200:
         abort(response.status)
     return response.raw_data
+
 
 def perform_public_request(url):
     try:
@@ -33,33 +37,36 @@ def perform_public_request(url):
     except urllib2.HTTPError, err:
         abort(err.code)
 
+
 def search_event(search, pageNumber):
     try:
         search = urllib.quote(search)
     except Exception:
         return []
     path = '/export/event/search/' + search + '.json'
-    params = { 'nocache': 'yes' if app.config.get("DEBUG", False) else "no",
+    params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no',
               'order': 'start',
               'descending': 'yes',
               'limit': 20,
-              'offset': (pageNumber -1 )* 20
-    }
+              'offset': (pageNumber - 1) * 20}
     if 'indico_mobile_oauthtok' in flask_session:
         result = perform_signed_request(construct_url(path, attach_params(params)))
     else:
-        params["ak"] = app.config['API_KEY']
+        params['ak'] = app.config['API_KEY']
         result = perform_public_request(construct_url(path, attach_params(params)))
-    return json.loads(result.decode('utf-8'))["results"]
+    return json.loads(result.decode('utf-8'))['results']
+
 
 def get_event_info(event_id):
     path = '/export/event/' + event_id + '.json'
+    params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no'}
     if 'indico_mobile_oauthtok' in flask_session:
-        result = perform_signed_request(construct_url(path, attach_params({'nocache': 'yes' if app.config.get("DEBUG", False) else "no"})))
+        result = perform_signed_request(construct_url(path, attach_params(params)))
     else:
-        result = perform_public_request(construct_url(path, attach_params({'nocache': 'yes' if app.config.get("DEBUG", False) else "no", 'ak': app.config['API_KEY']})))
-    event_info = json.loads(result.decode('utf-8'))["results"]
-    if len(event_info)== 0:
+        params['ak'] = app.config['API_KEY']
+        result = perform_public_request(construct_url(path, attach_params(params)))
+    event_info = json.loads(result.decode('utf-8'))['results']
+    if not event_info:
         return None
     return event_info[0]
 
@@ -67,53 +74,49 @@ def get_event_info(event_id):
 def fetch_timetable(event_id):
     path = '/export/timetable/' + event_id + '.json'
     if 'indico_mobile_oauthtok' in flask_session:
-        result = perform_signed_request(construct_url(path, attach_params({'nocache': 'yes' if app.config.get("DEBUG", False) else "no"})))
-    else:
-        result = perform_public_request(construct_url(path, attach_params({"ak": app.config['API_KEY']})))
-    return json.loads(result.decode('utf-8'))["results"]
-
-def get_ongoing_events():
-    result = perform_public_request('{0}/export/categ/0.json?ak={1}&from=now&to=now'.format(
-            app.config['INDICO_URL'], app.config['API_KEY']))
-    return json.loads(result.decode('utf-8'))['results']
-
-def get_today_events(user_id):
-    path = '/export/categ/0.json'
-    params = { 'nocache': 'yes' if app.config.get("DEBUG", False) else "no",
-              'from': 'now',
-              'to': 'today',
-              'order': 'start'
-    }
-    if user_id != 'all_public':
+        params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no'}
         result = perform_signed_request(construct_url(path, attach_params(params)))
     else:
-        params["ak"] = app.config['API_KEY']
+        {'ak': app.config['API_KEY']}
         result = perform_public_request(construct_url(path, attach_params(params)))
-    result = json.loads(result.decode('utf-8'))
-    return result["results"], result["additionalInfo"]["moreFutureEvents"]
+    return json.loads(result.decode('utf-8'))['results']
+
+
+def get_ongoing_events():
+    result = perform_public_request('{0[INDICO_URL]}/export/categ/0.json?ak={0[API_KEY]}&from=now&to=now'
+                                    .format(app.config))
+    return json.loads(result.decode('utf-8'))['results']
+
+
+def get_today_events(user_id):
+    return get_future_events(user_id, 'now', 'today')
+
 
 def get_future_events(user_id, startDate, endDate):
     path = '/export/categ/0.json'
-    params = { 'nocache': 'yes' if app.config.get("DEBUG", False) else "no",
+    params = {'nocache': 'yes' if app.config.get('DEBUG', False) else 'no',
               'from': startDate,
               'to': endDate,
-              'order': 'start'
-    }
+              'order': 'start'}
     if user_id != 'all_public':
         result = perform_signed_request(construct_url(path, attach_params(params)))
     else:
-        params["ak"] = app.config['API_KEY']
+        params['ak'] = app.config['API_KEY']
         result = perform_public_request(construct_url(path, attach_params(params)))
     result = json.loads(result.decode('utf-8'))
-    return result["results"], result["additionalInfo"]["moreFutureEvents"]
+    return result['results'], result['additionalInfo']['moreFutureEvents']
+
 
 def get_user_info(user_id):
-    return oauth_indico_mobile.get(construct_url("/export/user/%s.json"%user_id, {})).data["results"][0]
+    response = indico.get(construct_url('/export/user/{}.json'.format(user_id), {}))
+    json_response = response.json()
+    return json_response['results'][0]
+
 
 def get_room(room_name):
     path = '/export/roomName/CERN/' + urllib.quote(room_name) + '.json'
     if 'indico_mobile_oauthtok' in flask_session:
         result = perform_signed_request(construct_url(path, attach_params({})))
     else:
-        result = perform_public_request(construct_url(path, attach_params({"ak": app.config['API_KEY']})))
-    return json.loads(result.decode('utf-8'))["results"]
+        result = perform_public_request(construct_url(path, attach_params({'ak': app.config['API_KEY']})))
+    return json.loads(result.decode('utf-8'))['results']

--- a/indicomobile/core/indico_api.py
+++ b/indicomobile/core/indico_api.py
@@ -2,6 +2,8 @@ import urllib2
 import urllib
 from urlparse import urlparse, urlunparse
 
+import requests
+
 from flask import json, session as flask_session, abort
 from indicomobile.views.authentication import indico
 from indicomobile import app
@@ -25,9 +27,9 @@ def attach_params(params):
 
 def perform_signed_request(url):
     response = indico.get(url)
-    if response.status != 200:
+    if response.status_code != requests.codes.ok:
         abort(response.status)
-    return response.raw_data
+    return response.raw
 
 
 def perform_public_request(url):

--- a/indicomobile/core/indico_api.py
+++ b/indicomobile/core/indico_api.py
@@ -1,21 +1,12 @@
 import urllib2
 import urllib
-from urlparse import urlparse, urlunparse
 
 import requests
 
 from flask import json, session as flask_session, abort
-from indicomobile.views.authentication import indico
 from indicomobile import app
-
-
-def construct_url(path, params):
-    url_fragments = urlparse(app.config['INDICO_URL'])
-    url_path = url_fragments.path
-    if url_path and url_path[-1] == '/':
-        url_path = url_path[:-1]
-    url_path += path
-    return urlunparse((url_fragments.scheme, url_fragments.netloc, url_path, '', params, ''))
+from indicomobile.util.tools import construct_url
+from indicomobile.views.authentication import indico
 
 
 def attach_params(params):
@@ -107,12 +98,6 @@ def get_future_events(user_id, startDate, endDate):
         result = perform_public_request(construct_url(path, attach_params(params)))
     result = json.loads(result.decode('utf-8'))
     return result['results'], result['additionalInfo']['moreFutureEvents']
-
-
-def get_user_info(user_id):
-    response = indico.get(construct_url('/export/user/{}.json'.format(user_id), {}))
-    json_response = response.json()
-    return json_response['results'][0]
 
 
 def get_room(room_name):

--- a/indicomobile/templates/baselayout.html
+++ b/indicomobile/templates/baselayout.html
@@ -37,9 +37,9 @@
             </div>
             <div class="banner-buttons-right">
                 {% if session['indico_user'] %}
-                    <a data-role="button" href="{{url_for('oauth_client.logout')}}" rel="external" class="icon-logout panel-button-icon" aria-hidden="true"></a>
+                    <a data-role="button" href="{{url_for('oauth_blueprint.logout')}}" rel="external" class="icon-logout panel-button-icon" aria-hidden="true"></a>
                 {% else %}
-                    <a data-role="button" href="{{url_for('oauth_client.login')}}" rel="external" class="icon-login panel-button-icon" aria-hidden="true"></a>
+                    <a data-role="button" href="{{url_for('oauth_blueprint.login')}}" rel="external" class="icon-login panel-button-icon" aria-hidden="true"></a>
                 {% endif %}
                 <a data-role="button" href="{{url_for('routing.search')}}" rel="external" class="icon-search panel-button-icon" aria-hidden="true"></a>
             </div>

--- a/indicomobile/templates/dialogs.html
+++ b/indicomobile/templates/dialogs.html
@@ -4,7 +4,7 @@
   </div>
   <div data-role="content">
     <p>It seems the event you are trying to access is restricted and you cannot  access. Please try to login in the system.</p>
-    <a href="{{url_for('oauth_client.login')}}" data-role="button" data-inline="true" data-transition="flow" data-theme="b" rel="external">Login</a>
+    <a href="{{url_for('oauth_blueprint.login')}}" data-role="button" data-inline="true" data-transition="flow" data-theme="b" rel="external">Login</a>
 
   </div>
 </div>

--- a/indicomobile/util/tools.py
+++ b/indicomobile/util/tools.py
@@ -1,5 +1,6 @@
 from lxml import html
 
+
 def clean_html_tags(obj):
     obj["title"] = unicode(html.fromstring(obj["title"]).text_content())
     description = obj.get('description', '').strip()

--- a/indicomobile/views/authentication.py
+++ b/indicomobile/views/authentication.py
@@ -57,7 +57,7 @@ def oauth_authorized():
     session['indico_user'] = response['user_id']
     session['oauth_token_expiration_timestamp'] = response['oauth_token_expiration_timestamp']
     session['oauth_token_ttl'] = int(response['oauth_token_ttl'])
-    user_info = get_user_info(response['user_id'])
+    user_info = _get_user_info()
     session['indico_user_name'] = '{} {} {}'.format(user_info.get('title'), user_info.get('firstName'),
                                                     user_info.get('familyName'))
     return redirect(next_url)
@@ -84,3 +84,8 @@ def error(error):
     else:
         exception = BadRequest(error.data["message"])
     return generic_error_handler(exception)
+
+
+def _get_user_info():
+    response = indico.get('/api/user')
+    return response.json()

--- a/indicomobile/views/events.py
+++ b/indicomobile/views/events.py
@@ -1,15 +1,14 @@
 from datetime import timedelta, datetime
 from flask import json, Blueprint, Response, abort, session as flask_session, request
 
-from indicomobile import app
 import indicomobile.db.session as db_session
 import indicomobile.db.event as db_event
 import indicomobile.db.contribution as db_contribution
 import indicomobile.core.event as event
 import indicomobile.core.favorites as favorites
-from indicomobile.core.cache import cache, make_cache_key
 
 events = Blueprint('events', __name__, template_folder='templates')
+
 
 @events.before_request
 def with_event(event_id=None):
@@ -18,6 +17,7 @@ def with_event(event_id=None):
     """
     event_id = request.view_args.get('event_id')
     event.update_event_info(event_id)
+
 
 @events.route('/services/event/<event_id>/days/', methods=['GET'])
 def get_event_days(event_id):
@@ -33,16 +33,19 @@ def get_event_day(event_id, day_date):
 def get_event_same_sessions(event_id, session_id):
     return Response(json.dumps(event.get_event_same_sessions(event_id, session_id)), mimetype='application/json')
 
+
 @events.route('/services/event/<event_id>/session/<session_id>/', methods=['GET'])
 def get_event_same_session(event_id, session_id):
-    return Response(json.dumps(db_session.get_event_same_sessions(event_id, session_id)[0]), mimetype='application/json')
+    return Response(json.dumps(db_session.get_event_same_sessions(event_id, session_id)[0]),
+                    mimetype='application/json')
 
 
 @events.route('/services/event/<event_id>/day/<day_date>/session/<session_id>/', methods=['GET'])
 def get_event_day_sessions(event_id, session_id, day_date):
     start_date = datetime.strptime(day_date, '%Y-%m-%d')
     end_date = start_date + timedelta(days=1)
-    return Response(json.dumps(db_session.get_event_day_session(event_id, session_id, start_date, end_date)[0]), mimetype='application/json')
+    return Response(json.dumps(db_session.get_event_day_session(event_id, session_id, start_date, end_date)[0]),
+                    mimetype='application/json')
 
 
 @events.route('/services/event/<event_id>/contrib/<contrib_id>/', methods=['GET'])
@@ -62,17 +65,20 @@ def get_event_sessions(event_id):
 
 @events.route('/services/event/<event_id>/session/<session_id>/day/<day>/contribs/', methods=['GET'])
 def get_session_day_contributions(event_id, session_id, day):
-    return Response(json.dumps(event.get_session_day_contributions(event_id, session_id, day)), mimetype='application/json')
+    return Response(json.dumps(event.get_session_day_contributions(event_id, session_id, day)),
+                    mimetype='application/json')
 
 
 @events.route('/services/event/<event_id>/speaker/<speaker_id>/contributions/', methods=['GET'])
 def get_speaker_contributions(event_id, speaker_id):
-    return Response(json.dumps(sorted(event.get_speaker_contributions(event_id, speaker_id))), mimetype='application/json')
+    return Response(json.dumps(sorted(event.get_speaker_contributions(event_id, speaker_id))),
+                    mimetype='application/json')
 
 
 @events.route('/services/event/<event_id>/speakers/', methods=['GET'])
 def get_event_speakers(event_id):
-    return Response(json.dumps(event.get_event_speakers(event_id, int(request.args.get('page', 1)))), mimetype='application/json')
+    return Response(json.dumps(event.get_event_speakers(event_id, int(request.args.get('page', 1)))),
+                    mimetype='application/json')
 
 
 @events.route('/services/event/<event_id>/speaker/<speaker_id>/', methods=['GET'])
@@ -108,8 +114,8 @@ def search_event(search):
 def get_ongoing_events():
     return Response(json.dumps(event.get_ongoing_events(int(request.args.get('page', 1)))), mimetype='application/json')
 
+
 @events.route('/services/ongoingContributions/', methods=['GET'])
-#@cache.cached(key_prefix=make_cache_key)
 def get_ongoing_contributions():
     return Response(json.dumps(event.get_ongoing_contributions()), mimetype='application/json')
 

--- a/indicomobile/views/routing.py
+++ b/indicomobile/views/routing.py
@@ -30,7 +30,7 @@ def events():
 @routing.route('/event/<event_id>')
 def event(event_id):
     if request.args.get('pr', "no") == "yes" and "indico_mobile_oauthtok" not in session:
-        return redirect(url_for("oauth_client.login", next=request.url))
+        return redirect(url_for('oauth_blueprint.login', next=request.url))
     return redirect(url_for("routing.events") + "#event_" + event_id)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-Assets==0.8
 Flask-MongoKit==0.6
 Flask-Cache==0.12
 Flask-OAuth==0.12
+https://github.com/lepture/flask-oauthlib/archive/master.zip#egg=Flask-OAuthlib-dev
 pytz==2013.9
 lxml==3.3.1
 jsmin==2.0.9

--- a/settings.conf.sample
+++ b/settings.conf.sample
@@ -57,15 +57,14 @@ API_KEY = 'your_api_key'
 #------------------------------------------------------------------------------
 # OAUTH CONFIGURATION
 #
-# We specified the OAUTH configuration
+# We specified the OAUTH2 configuration
 #------------------------------------------------------------------------------
 
-REQUEST_TOKEN_URL='http://yourindicoserver/oauth/request_token'
-ACCESS_TOKEN_URL='http://yourindicoserver/oauth/access_token'
-AUTHORIZE_URL='http://yourindicoserver/oauth/authorize'
-CONSUMER_KEY=''  # set whatever Indico generates
-CONSUMER_SECRET=''  # set whatever Indico generates
-CERT_FILE='/path/to/cert/file'  # cert used to verify Indico's certificate
+ACCESS_TOKEN_URL='https://yourindicoserver/oauth/token'
+AUTHORIZE_URL='https://yourindicoserver/oauth/authorize'
+CLIENT_ID=''                                             # set whatever Indico generates
+CLIENT_SECRET=''                                         # set whatever Indico generates
+#CERT_FILE='/path/to/cert/file'                           # cert to verify Indico's certificate (optional)
 
 #------------------------------------------------------------------------------
 # Statistics

--- a/settings.conf.sample
+++ b/settings.conf.sample
@@ -65,7 +65,7 @@ ACCESS_TOKEN_URL='http://yourindicoserver/oauth/access_token'
 AUTHORIZE_URL='http://yourindicoserver/oauth/authorize'
 CONSUMER_KEY=''  # set whatever Indico generates
 CONSUMER_SECRET=''  # set whatever Indico generates
-
+CERT_FILE='/path/to/cert/file'  # cert used to verify Indico's certificate
 
 #------------------------------------------------------------------------------
 # Statistics


### PR DESCRIPTION
Update to Oauth2
- replaces `flask-oauth` with `flask-oauthlib`
- API calls now using `requests` or `request-oauthlib` (through `flask-oauthlib`'s "contrib" client) if authenticated
- update the sample `settings.conf`